### PR TITLE
Several fixes - textures loading, profile switching

### DIFF
--- a/KS3P.cs
+++ b/KS3P.cs
@@ -96,18 +96,24 @@ namespace KSP_PostProcessing
         }
 
         /// <summary>
+        /// The current status of the KS3P.
+        /// </summary>
+        static private bool KS3P_active = true;
+
+        /// <summary>
         /// KS3P enabled status
         /// <para>Get: returns the current status of KS3P: enabled or not?</para>
         /// <para>Set: either enables or disables KS3P depending on the value given.</para>
         /// </summary>
-        static bool KS3P_Enabled
+        internal static bool KS3P_Enabled
         {
-            get => (cam) ? cam.enabled : false;
+            get => KS3P_active;
             set
             {
                 if (cam)
                 {
                     cam.enabled = value;
+                    KS3P_active = value;
                 }
                 else
                 {
@@ -134,6 +140,7 @@ namespace KSP_PostProcessing
                 KS3P.Log("Switch to profile \"" + loadedProfiles[targetScenes[(int)targetScene]].ProfileName + "\"");
             }
             cam = target;
+            cam.enabled = KS3P_Enabled;
         }
 
         // Registers a new texture references (so the GUI can manage and/or assign them)

--- a/KS3P.cs
+++ b/KS3P.cs
@@ -1,9 +1,9 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
-using UnityEngine;
-using System;
 using System.Linq;
 using System.IO;
+using UnityEngine;
 
 namespace KSP_PostProcessing
 {
@@ -266,7 +266,7 @@ namespace KSP_PostProcessing
         /// <summary>
         /// The GUI window's size.
         /// </summary>
-        internal Rect rect = new Rect(0f, 0f, 300f, 500f);
+        internal Rect rect = new Rect(10f, 60f, 300f, 500f);
 
         /// <summary>
         /// The cached value of most GUI items
@@ -718,8 +718,8 @@ namespace KSP_PostProcessing
 
                 #region EditProfileSettings
                 case EditorWindowStatus.ProfileSettingsEditor:
-                    loadedProfiles[currentProfile].AuthorName = NamedStringField(loadedProfiles[currentProfile].AuthorName, 0f, "Name");
-                    loadedProfiles[currentProfile].ProfileName = NamedStringField(loadedProfiles[currentProfile].ProfileName, 1f, "Author");
+                    loadedProfiles[currentProfile].AuthorName = NamedStringField(loadedProfiles[currentProfile].AuthorName, 0f, "Author");
+                    loadedProfiles[currentProfile].ProfileName = NamedStringField(loadedProfiles[currentProfile].ProfileName, 1f, "Name");
 
                     for (int i = 0; i < 9; i++)
                     {
@@ -1119,8 +1119,8 @@ namespace KSP_PostProcessing
                     }
 
                     DrawFloatSlider("Red", ref channelvalues.x, "cg_mix_r", 1f, -2f, 2f);
-                    DrawFloatSlider("Red", ref channelvalues.y, "cg_mix_g", 2f, -2f, 2f);
-                    DrawFloatSlider("Red", ref channelvalues.z, "cg_mix_b", 3f, -2f, 2f);
+                    DrawFloatSlider("Green", ref channelvalues.y, "cg_mix_g", 2f, -2f, 2f);
+                    DrawFloatSlider("Blue", ref channelvalues.z, "cg_mix_b", 3f, -2f, 2f);
 
                     switch (channel)
                     {

--- a/KS3P.cs
+++ b/KS3P.cs
@@ -876,8 +876,8 @@ namespace KSP_PostProcessing
                     bloom.softKnee = FloatValue("b_sk", GetValue(3f));
 
                     Text("Radius", GetLabel(4f));
-                    bloom.radius = FloatSlider(bloom.radius, "b_r", GetField(4f), 1f, 7f);
-                    bloom.radius = FloatValue("b_r", GetValue(4f), 1f, 7f);
+                    bloom.radius = FloatSlider(bloom.radius, "b_r", GetField(4f), 0.75f, 7f);
+                    bloom.radius = FloatValue("b_r", GetValue(4f), 0.75f, 7f);
 
                     bloom.antiFlicker = CachedBoolField(bloom.antiFlicker, GetRect(5f), "b_af", "Anti Flicker");
 

--- a/KS3PUtil.cs
+++ b/KS3PUtil.cs
@@ -238,7 +238,14 @@ namespace KSP_PostProcessing
         internal static Vector2 GetBounds(this AnimationCurve curve)
         {
             var frames = curve.keys;
-            return new Vector2(frames[0].time, frames[frames.Length - 1].time);
+            if (frames.Length == 0)
+            {
+                return Vector2.zero;
+            }
+            else
+            {
+                return new Vector2(frames[0].time, frames[frames.Length - 1].time);
+            }
         }
     }
 }

--- a/KS3PUtil.cs
+++ b/KS3PUtil.cs
@@ -16,7 +16,7 @@ namespace KSP_PostProcessing
         /// </summary>
         /// <param name="s"></param>
         /// <returns></returns>
-        internal static string Prepare(string s) => s.Replace("_", string.Empty).ToLower();
+        internal static string Prepare(string s) => s.Replace("_", string.Empty).ToLower().Trim();
         internal static bool Contains<T>(this T[] array, T item)
         {
             for(int x = 0; x < array.Length; x++)

--- a/KS3PUtil.cs
+++ b/KS3PUtil.cs
@@ -101,11 +101,11 @@ namespace KSP_PostProcessing
 
         internal static string TrimRGBA(this string s)
         {
-            char[] separator = { '(' };
-            string[] parts = s.Split(separator);
-            separator = new char[1] { ')' };
-            parts = parts[1].Split(separator);
-            return parts[0];
+            if(s.TrimStart(' ').ToLower().StartsWith("rgba"))
+            {
+                return s.TrimStart(' ').Remove(0, 4).TrimStart(' ', '(').TrimEnd(' ', ')');
+            }
+            return s;
         }
 
         internal static bool TryParseKeyframe(string input, out Keyframe output)

--- a/Operators/FlightOperator.cs
+++ b/Operators/FlightOperator.cs
@@ -5,23 +5,29 @@ namespace KSP_PostProcessing.Operators
     [KSPAddon(KSPAddon.Startup.Flight, false)]
     public class FlightOperator : MonoBehaviour
     {
-        byte state = 0xff;
-        // 0 = flight
-        // 1 = EVA
-        // 2 = IVA
-        // 3 = Map
-        // 0xff = Unknown, set to flight
+        enum State
+        {
+            Flight,
+            EVA,
+            IVA,
+            Map,
+            Initial
+        }
+
+        State activeState = State.Initial;
 
         private void Start()
         {
             mainCam = Camera.main.gameObject.AddOrGetComponent<PostProcessingBehaviour>();
-            scaledCam = GameObject.Find("Camera ScaledSpace").AddOrGetComponent<PostProcessingBehaviour>();
-            ivaCam = InternalCamera.Instance;
+            scaledCam = ScaledCamera.Instance.gameObject.AddOrGetComponent<PostProcessingBehaviour>();
+            ivaCamInstance = InternalCamera.Instance;
+            ivaCam = ivaCamInstance.gameObject.AddOrGetComponent<PostProcessingBehaviour>();
         }
 
         PostProcessingBehaviour mainCam;
         PostProcessingBehaviour scaledCam;
-        InternalCamera ivaCam;
+        PostProcessingBehaviour ivaCam;
+        InternalCamera ivaCamInstance;
 
         private void Update()
         {
@@ -29,40 +35,43 @@ namespace KSP_PostProcessing.Operators
             {
                 return;
             }
-            if(MapView.MapIsEnabled)
+            if (MapView.MapIsEnabled)
             {
-                if(state != 3)
+                if (activeState != State.Map)
                 {
-                    KS3P.Register(scaledCam, KS3P.Scene.MapView);
                     KS3P.currentScene = KS3P.Scene.MapView;
-                    state = 3;
+                    KS3P.Register(scaledCam, KS3P.Scene.MapView);
+                    activeState = State.Map;
                 }
             }
-            else if(ivaCam.isActive)
+            else if (ivaCamInstance.isActive)
             {
-                if(state != 2)
+                if (activeState != State.IVA)
                 {
-                    KS3P.Register(mainCam, KS3P.Scene.IVA);
+                    scaledCam.enabled = false;
                     KS3P.currentScene = KS3P.Scene.IVA;
-                    state = 2;
+                    KS3P.Register(ivaCam, KS3P.Scene.IVA);
+                    activeState = State.IVA;
                 }
             }
-            else if(FlightGlobals.ActiveVessel.isEVA)
+            else if (FlightGlobals.ActiveVessel.isEVA)
             {
-                if(state != 1)
+                if (activeState != State.EVA)
                 {
-                    KS3P.Register(mainCam, KS3P.Scene.EVA);
+                    scaledCam.enabled = false;
                     KS3P.currentScene = KS3P.Scene.EVA;
-                    state = 1;
+                    KS3P.Register(mainCam, KS3P.Scene.EVA);
+                    activeState = State.EVA;
                 }
             }
             else
             {
-                if(state != 0)
+                if (activeState != State.Flight)
                 {
-                    KS3P.Register(mainCam, KS3P.Scene.Flight);
+                    scaledCam.enabled = false;
                     KS3P.currentScene = KS3P.Scene.Flight;
-                    state = 0;
+                    KS3P.Register(mainCam, KS3P.Scene.Flight);
+                    activeState = State.Flight;
                 }
             }
         }

--- a/Operators/FlightOperator.cs
+++ b/Operators/FlightOperator.cs
@@ -5,16 +5,17 @@ namespace KSP_PostProcessing.Operators
     [KSPAddon(KSPAddon.Startup.Flight, false)]
     public class FlightOperator : MonoBehaviour
     {
-        byte state = 0;
+        byte state = 0xff;
         // 0 = flight
         // 1 = EVA
         // 2 = IVA
         // 3 = Map
-        
+        // 0xff = Unknown, set to flight
+
         private void Start()
         {
             mainCam = Camera.main.gameObject.AddOrGetComponent<PostProcessingBehaviour>();
-            scaledCam = GameObject.Find("Camera ScaledSpace").AddOrGetComponent<PostProcessingBehaviour>(); ;
+            scaledCam = GameObject.Find("Camera ScaledSpace").AddOrGetComponent<PostProcessingBehaviour>();
             ivaCam = InternalCamera.Instance;
         }
 

--- a/Operators/PostProcessingOperator.cs
+++ b/Operators/PostProcessingOperator.cs
@@ -8,10 +8,19 @@ namespace KSP_PostProcessing.Operators
 
         protected internal void Patch(bool scaled, KS3P.Scene target)
         {
-            GameObject cam = (scaled) ? GameObject.Find("Camera ScaledSpace") : Camera.main.gameObject;
+            GameObject cam = scaled ? ScaledCamera.Instance.gameObject : Camera.main.gameObject;
 
-            if(cam)
+            if (cam)
             {
+                if (!scaled)
+                {
+                    GameObject scaledCam = ScaledCamera.Instance.gameObject;
+                    if (scaledCam)
+                    {
+                        scaledCam.AddOrGetComponent<PostProcessingBehaviour>().enabled = false;
+                    }
+                }
+
                 KS3P.Register(cam.AddOrGetComponent<PostProcessingBehaviour>(), target);
             }
         }

--- a/Parser.cs
+++ b/Parser.cs
@@ -845,21 +845,21 @@ namespace KSP_PostProcessing.Parsers
                             else
                             {
                                 Warning("Failed to load dirt texture path [" + data[1] + "], loading blank fallback texture.");
-                                dirtSettings.texture = database.GetTexture("KS3P/Textures/Fallback.png", false);
-                                path = "KS3P/Textures/Fallback.png";
+                                dirtSettings.texture = database.GetTexture("KS3P/Textures/Fallback", false);
+                                path = "KS3P/Textures/Fallback";
                             }
                         }
                         else
                         {
-                            dirtSettings.texture = GameDatabase.Instance.GetTexture("KS3P/Textures/Fallback.png", false);
-                            path = "KS3P/Textures/Fallback.png";
+                            dirtSettings.texture = GameDatabase.Instance.GetTexture("KS3P/Textures/Fallback", false);
+                            path = "KS3P/Textures/Fallback";
                         }
                     }
                     else
                     {
                         dirtSettings.intensity = 0f; // disable
-                        dirtSettings.texture = GameDatabase.Instance.GetTexture("KS3P/Textures/Fallback.png", false);
-                        path = "KS3P/Textures/Fallback.png";
+                        dirtSettings.texture = GameDatabase.Instance.GetTexture("KS3P/Textures/Fallback", false);
+                        path = "KS3P/Textures/Fallback";
                     }
                 }
                 else
@@ -886,14 +886,14 @@ namespace KSP_PostProcessing.Parsers
                         else
                         {
                             Warning("Failed to load dirt texture path [" + data[1] + "], loading blank fallback texture.");
-                            dirtSettings.texture = database.GetTexture("KS3P/Textures/Fallback.png", false);
-                            path = "KS3P/Textures/Fallback.png";
+                            dirtSettings.texture = database.GetTexture("KS3P/Textures/Fallback", false);
+                            path = "KS3P/Textures/Fallback";
                         }
                     }
                     else
                     {
-                        dirtSettings.texture = GameDatabase.Instance.GetTexture("KS3P/Textures/Fallback.png", false);
-                        path = "KS3P/Textures/Fallback.png";
+                        dirtSettings.texture = GameDatabase.Instance.GetTexture("KS3P/Textures/Fallback", false);
+                        path = "KS3P/Textures/Fallback";
                     }
                 }
             }
@@ -921,14 +921,14 @@ namespace KSP_PostProcessing.Parsers
                     else
                     {
                         Warning("Failed to load dirt texture path [" + data[1] + "], loading blank fallback texture.");
-                        dirtSettings.texture = database.GetTexture("KS3P/Textures/Fallback.png", false);
-                        path = "KS3P/Textures/Fallback.png";
+                        dirtSettings.texture = database.GetTexture("KS3P/Textures/Fallback", false);
+                        path = "KS3P/Textures/Fallback";
                     }
                 }
                 else
                 {
-                    dirtSettings.texture = GameDatabase.Instance.GetTexture("KS3P/Textures/Fallback.png", false);
-                    path = "KS3P/Textures/Fallback.png";
+                    dirtSettings.texture = GameDatabase.Instance.GetTexture("KS3P/Textures/Fallback", false);
+                    path = "KS3P/Textures/Fallback";
                 }
             }
 
@@ -1503,14 +1503,14 @@ namespace KSP_PostProcessing.Parsers
                 else
                 {
                     Warning("Failed to load dirt texture path [" + data[1] + "], loading blank fallback texture.");
-                    settings.lut = database.GetTexture("KS3P/Textures/Fallback.png", false);
-                    path = "KS3P/Textures/Fallback.png";
+                    settings.lut = database.GetTexture("KS3P/Textures/Fallback", false);
+                    path = "KS3P/Textures/Fallback";
                 }
             }
             else
             {
-                settings.lut = database.GetTexture("KS3P/Textures/Fallback.png", false);
-                path = "KS3P/Textures/Fallback.png";
+                settings.lut = database.GetTexture("KS3P/Textures/Fallback", false);
+                path = "KS3P/Textures/Fallback";
             }
             
             if(data[2] == null || !bool.TryParse(data[2], out enabled))
@@ -1578,14 +1578,14 @@ namespace KSP_PostProcessing.Parsers
                 else
                 {
                     Warning("Failed to load spectral texture path [" + data[1] + "], loading blank fallback texture.");
-                    settings.spectralTexture = database.GetTexture("KS3P/Textures/Fallback.png", false);
-                    path = "KS3P/Textures/Fallback.png";
+                    settings.spectralTexture = database.GetTexture("KS3P/Textures/Fallback", false);
+                    path = "KS3P/Textures/Fallback";
                 }
             }
             else
             {
-                settings.spectralTexture = database.GetTexture("KS3P/Textures/Fallback.png", false);
-                path = "KS3P/Textures/Fallback.png";
+                settings.spectralTexture = database.GetTexture("KS3P/Textures/Fallback", false);
+                path = "KS3P/Textures/Fallback";
             }
 
             if (data[2] == null || !bool.TryParse(data[2], out enabled))
@@ -1739,14 +1739,14 @@ namespace KSP_PostProcessing.Parsers
                 else
                 {
                     Warning("Failed to load mask texture path [" + data[3] + "], loading blank fallback texture.");
-                    settings.mask = database.GetTexture("KS3P/Textures/Fallback.png", false);
-                    path = "KS3P/Textures/Fallback.png";
+                    settings.mask = database.GetTexture("KS3P/Textures/Fallback", false);
+                    path = "KS3P/Textures/Fallback";
                 }
             }
             else
             {
-                settings.mask = database.GetTexture("KS3P/Textures/Fallback.png", false);
-                path = "KS3P/Textures/Fallback.png";
+                settings.mask = database.GetTexture("KS3P/Textures/Fallback", false);
+                path = "KS3P/Textures/Fallback";
             }
             if(data[4] != null)
             {

--- a/Parser.cs
+++ b/Parser.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using UnityEngine;
-using System.Collections.Generic;
 using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
 
 namespace KSP_PostProcessing.Parsers
 {
@@ -107,7 +107,7 @@ namespace KSP_PostProcessing.Parsers
             float[] data = { 0f, 0f, 0f };
             char[] separator = { ',' };
 
-            string[] snippets = target.Split(separator, 3);
+            string[] snippets = target.TrimStart(' ', '(').TrimEnd(' ', ')').Split(separator, 3);
             float parsed = 0f;
             for(int i = 0; i < snippets.Length; i++)
             {
@@ -1423,11 +1423,11 @@ namespace KSP_PostProcessing.Parsers
 
             lines.AddIndented("tonemapper", mapSettings.tonemapper, mapDef.tonemapper);
             lines.AddIndented("black_in", mapSettings.neutralBlackIn, mapDef.neutralBlackIn);
-            lines.AddIndented("black_out", mapSettings.neutralBlackOut, mapDef.neutralBlackOut);
-            lines.AddIndented("white_clip", mapSettings.neutralWhiteClip, mapDef.neutralWhiteClip);
             lines.AddIndented("white_in", mapSettings.neutralWhiteIn, mapDef.neutralWhiteIn);
-            lines.AddIndented("white_level", mapSettings.neutralWhiteLevel, mapDef.neutralWhiteLevel);
+            lines.AddIndented("black_out", mapSettings.neutralBlackOut, mapDef.neutralBlackOut);
             lines.AddIndented("white_out", mapSettings.neutralWhiteOut, mapDef.neutralWhiteOut);
+            lines.AddIndented("white_level", mapSettings.neutralWhiteLevel, mapDef.neutralWhiteLevel);
+            lines.AddIndented("white_clip", mapSettings.neutralWhiteClip, mapDef.neutralWhiteClip);
 
             lines.AddIndented(false);
             #endregion
@@ -1655,7 +1655,7 @@ namespace KSP_PostProcessing.Parsers
 
         internal override void ToFile(List<string> lines, GrainModel item)
         {
-            lines.AddIndented("Grain_Model");
+            lines.AddIndented("Grain");
             lines.AddIndented(true);
 
             var settings = item.settings;

--- a/Parser.cs
+++ b/Parser.cs
@@ -13,7 +13,7 @@ namespace KSP_PostProcessing.Parsers
     {
         protected void Warning(string message)
         {
-            KS3P.Error("[" + nameof(T) + "]: message");
+            KS3P.Error("[" + nameof(T) + "]: " + message);
         }
         protected void Exception(string message, Exception exception)
         {
@@ -166,13 +166,12 @@ namespace KSP_PostProcessing.Parsers
             if(node == null)
             {
                 curve = null;
-                return false;
             }
             else
             {
                 curve = ParseCurve(node);
-                return true;
             }
+            return (curve != null);
         }
 
         protected ColorGradingCurve ParseCurve(ConfigNode node)
@@ -201,7 +200,13 @@ namespace KSP_PostProcessing.Parsers
                     }
                 }
             }
-            return new ColorGradingCurve(curve, zero, loop, curve.GetBounds());
+
+            Vector2 cBounds = curve.GetBounds();
+            if (cBounds.IsZero()) {
+                return null;
+            } else {
+                return new ColorGradingCurve(curve, zero, loop, cBounds);
+            }
         }
 
         internal abstract void ToFile(List<string> lines, T item);
@@ -249,7 +254,7 @@ namespace KSP_PostProcessing.Parsers
             }
             catch (Exception e)
             {
-                KS3P.Exception("Exception caught parsing enumerator [" + nameof(E) + "]", e);
+                //KS3P.Exception("Exception caught parsing enumerator [" + nameof(E) + "]", e);
                 parsed = default(E);
                 return false;
             }

--- a/Parser.cs
+++ b/Parser.cs
@@ -252,7 +252,7 @@ namespace KSP_PostProcessing.Parsers
                 parsed = (E)Enum.Parse(typeof(E), enumString);
                 return true;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 //KS3P.Exception("Exception caught parsing enumerator [" + nameof(E) + "]", e);
                 parsed = default(E);

--- a/Parser.cs
+++ b/Parser.cs
@@ -134,29 +134,17 @@ namespace KSP_PostProcessing.Parsers
                 float[] data = { 0f, 0f, 0f, 1f };
                 char[] separator = { ',' };
 
-                string[] snippets = target.Split(separator, 3);
+                string[] snippets = target.TrimRGBA().Split(separator, 4);
                 float parsed = 0f;
 
-                if (target.StartsWith("RGBA"))
+                for (int i = 0; i < snippets.Length; i++)
                 {
-                    for (int i = 0; i < snippets.Length; i++)
+                    if (float.TryParse(snippets[i], out parsed))
                     {
-                        if (float.TryParse(snippets[i], out parsed))
-                        {
-                            data[i] = parsed / 255f;
-                        }
+                        data[i] = parsed;
                     }
                 }
-                else
-                {
-                    for (int i = 0; i < snippets.Length; i++)
-                    {
-                        if (float.TryParse(snippets[i], out parsed))
-                        {
-                            data[i] = parsed;
-                        }
-                    }
-                }
+
                 return new Color(data[0], data[1], data[2], data[3]);
             }
         }

--- a/Profile.cs
+++ b/Profile.cs
@@ -1,8 +1,7 @@
-﻿using UnityEngine;
-using System.IO;
-using KSP_PostProcessing.Parsers;
+﻿using System.Collections;
 using System.Collections.Generic;
-using System.Collections;
+using UnityEngine;
+using KSP_PostProcessing.Parsers;
 
 namespace KSP_PostProcessing
 {

--- a/ShaderLoader.cs
+++ b/ShaderLoader.cs
@@ -119,7 +119,7 @@ namespace KSP_PostProcessing
                     }
                     else
                     {
-                        KS3P.Warning("Adding shader [" + shader.name + "].", ref log);
+                        KS3P.Log("Adding shader [" + shader.name + "].", ref log);
                         shaderDictionary.Add(shader.name, shader);
                     }
                 }

--- a/ShaderLoader.cs
+++ b/ShaderLoader.cs
@@ -65,7 +65,7 @@ namespace KSP_PostProcessing
             string gpuString = SystemInfo.graphicsDeviceVersion;
 
             // check DX11
-
+#if !UNITY2019
             if(gpuString.Contains("Direct3D 11.0"))
             {
                 // inject dx11
@@ -73,6 +73,7 @@ namespace KSP_PostProcessing
                 path = Path.Combine(path, "postprocessingshaders-dx11");
             }
             else
+#endif
             {
                 // merge path but don't add dx11 targeting
                 path = Path.Combine(path, "postprocessingshaders");

--- a/Unity.cs
+++ b/Unity.cs
@@ -2229,9 +2229,7 @@ namespace KSP_PostProcessing
                     : GetPerspectiveProjectionMatrix(jitter);
             }
 
-#if UNITY_5_5_OR_NEWER
             context.camera.useJitteredProjectionMatrixForTransparentRendering = false;
-#endif
 
             jitter.x /= context.width;
             jitter.y /= context.height;
@@ -2299,9 +2297,13 @@ namespace KSP_PostProcessing
 
         Vector2 GenerateRandomOffset()
         {
+            // from v2:
+            // The variance between 0 and the actual halton sequence values reveals noticeable instability
+            // in Unity's shadow maps, so we avoid index 0.
             var offset = new Vector2(
-                    GetHaltonValue(m_SampleIndex & 1023, 2),
-                    GetHaltonValue(m_SampleIndex & 1023, 3));
+                    GetHaltonValue((m_SampleIndex & 1023) + 1, 2) - 0.5f,
+                    GetHaltonValue((m_SampleIndex & 1023) + 1, 3) - 0.5f
+                );
 
             if (++m_SampleIndex >= k_SampleCount)
                 m_SampleIndex = 0;
@@ -4644,9 +4646,7 @@ namespace KSP_PostProcessing
         { }
     }
 
-#if UNITY_5_4_OR_NEWER
     [ImageEffectAllowedInSceneView]
-#endif
     [RequireComponent(typeof(Camera)), DisallowMultipleComponent, ExecuteInEditMode]
     [AddComponentMenu("Effects/Post-Processing Behaviour", -1)]
     public class PostProcessingBehaviour : MonoBehaviour

--- a/Unity.cs
+++ b/Unity.cs
@@ -4646,9 +4646,9 @@ namespace KSP_PostProcessing
         { }
     }
 
-    [ImageEffectAllowedInSceneView]
+    //[ImageEffectAllowedInSceneView]
     [RequireComponent(typeof(Camera)), DisallowMultipleComponent, ExecuteInEditMode]
-    [AddComponentMenu("Effects/Post-Processing Behaviour", -1)]
+    //[AddComponentMenu("Effects/Post-Processing Behaviour", -1)]
     public class PostProcessingBehaviour : MonoBehaviour
     {
         // Inspector fields

--- a/Unity.cs
+++ b/Unity.cs
@@ -4570,12 +4570,7 @@ namespace KSP_PostProcessing
 
         public bool isHdr
         {
-            // No UNITY_5_6_OR_NEWER defined in early betas of 5.6
-#if UNITY_5_6 || UNITY_5_6_OR_NEWER
             get { return camera.allowHDR; }
-#else
-            get { return camera.hdr; }
-#endif
         }
 
         public int width


### PR DESCRIPTION
Implemented delayed loader for textures and profiles (textures was not not loaded before they are stored in the game database). Fixed bug that prevents to enable profile for flight scene. Scene ID parser from profile config slightly corrected. First found profile for the corresponded scene applied for now. Sample configs for testing 
[sample_configs.zip](https://github.com/TheWhiteGuardian/KS3P/files/3629850/sample_configs.zip)
Tested on KSP 1.7.3